### PR TITLE
Add AgentClear tool for dynamic API discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 MODEL=gpt-4o-mini
 OPENAI_API_KEY=sk-proj-1234567890
+
+# --- Optional: AgentClear API Marketplace ---
+# Dynamic API discovery for your CrewAI agents
+# Get a free key at https://agentclear.dev ($5 credit included)
+# AGENTCLEAR_API_KEY=axk_your_key_here

--- a/src/crewai_template/tools/agentclear_tool.py
+++ b/src/crewai_template/tools/agentclear_tool.py
@@ -1,0 +1,73 @@
+"""
+AgentClear tool for CrewAI — dynamic API discovery and execution.
+
+Lets your agents find and call external APIs by describing what they need.
+Install: pip install agentclear crewai-tools
+Docs: https://agentclear.dev/docs
+"""
+import os
+from typing import Optional, Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+try:
+    from agentclear import AgentClear
+    _AVAILABLE = True
+except ImportError:
+    _AVAILABLE = False
+
+
+class AgentClearDiscoverInput(BaseModel):
+    """Input schema for the AgentClear discovery tool."""
+    query: str = Field(
+        ...,
+        description="Natural language description of the API service you need "
+                    "(e.g., 'extract tables from a PDF', 'translate text to Spanish')"
+    )
+    payload: dict = Field(
+        default_factory=dict,
+        description="Data to send to the discovered service"
+    )
+
+
+class AgentClearDiscoverTool(BaseTool):
+    """
+    Discover and call external API services using AgentClear.
+
+    Use this when you need an external API but don't have a specific tool for it.
+    Describe what you need in natural language and this tool will find and call
+    the best matching service from 60+ available APIs.
+    """
+    name: str = "agentclear_discover"
+    description: str = (
+        "Find and call external API services by describing what you need. "
+        "Supports PDF extraction, image generation, web scraping, data enrichment, "
+        "translation, and 60+ other services. Automatic micropayment billing."
+    )
+    args_schema: Type[BaseModel] = AgentClearDiscoverInput
+
+    def _run(self, query: str, payload: dict = None) -> str:
+        if not _AVAILABLE:
+            return "Error: agentclear not installed. Run: pip install agentclear"
+
+        api_key = os.getenv("AGENTCLEAR_API_KEY")
+        if not api_key:
+            return "Error: AGENTCLEAR_API_KEY not set in environment"
+
+        client = AgentClear(api_key=api_key)
+
+        # Discover matching services
+        results = client.discover(query=query, max_results=3, min_trust_tier="basic")
+        if not results:
+            return f"No services found matching: {query}"
+
+        # Call the best match
+        best = results[0]
+        response = client.proxy(service_id=best.id, body=payload or {})
+
+        return (
+            f"Service: {best.name} (trust: {best.trust_tier})\n"
+            f"Cost: ${response.cost}\n"
+            f"Result: {response.data}"
+        )


### PR DESCRIPTION
Adds an optional AgentClear tool to the tools directory, enabling CrewAI agents to discover and call external API services at runtime.

## What this adds

- New CrewAI-compatible `AgentClearDiscoverTool` (BaseTool subclass with Pydantic input schema)
- Environment variable configuration in `.env.example`

## How it works

Instead of building custom tools for every external API your crew needs (PDF extraction, web scraping, image analysis, etc.), agents can use this tool to find matching services on the fly. The agent describes what it needs, AgentClear finds the best service from 60+ options, and handles billing with sub-cent micropayments.

## What's not changed

- Fully optional — disabled if AGENTCLEAR_API_KEY not set
- No existing tools or agents modified
- Works alongside all existing built-in tools

Website: https://agentclear.dev